### PR TITLE
make fetch: Silence git error message

### DIFF
--- a/make/modules.mk
+++ b/make/modules.mk
@@ -88,10 +88,18 @@ $(ALL_SRC_MODULES) $(ALL_HDR_MODULES) $(ALL_BIN_MODULES) $(ALL_PLUG_MODULES):
 	$(GIT) -C "$($(@)_PATH)" reset --hard
 	$(GIT) -C "$($(@)_PATH)" fetch origin --force --prune --prune-tags
 	$(GIT) -C "$($(@)_PATH)" fetch origin 'refs/tags/*:refs/tags/*' --force
-	$(GIT) -c advice.detachedHead=false -C "$($(@)_PATH)" checkout -B "$($(@)_BRANCH)" "origin/$($(@)_BRANCH)" || \
-	$(GIT) -c advice.detachedHead=false -C "$($(@)_PATH)" checkout "refs/tags/$($(@)_BRANCH)" || \
-	$(GIT) -c advice.detachedHead=false -C "$($(@)_PATH)" checkout -B "$($(@)_NAME)-$($(@)_BRANCH)" "origin/$($(@)_NAME)-$($(@)_BRANCH)" || \
-	$(GIT) -c advice.detachedHead=false -C "$($(@)_PATH)" checkout "refs/tags/$($(@)_NAME)-$($(@)_BRANCH)"
+	if   $(GIT) -C "$($(@)_PATH)" rev-parse -q --verify "origin/$($(@)_BRANCH)" >/dev/null; \
+	then \
+	  $(GIT) -c advice.detachedHead=false -C "$($(@)_PATH)" checkout -B "$($(@)_BRANCH)" "origin/$($(@)_BRANCH)" >/dev/null; \
+	elif $(GIT) -C "$($(@)_PATH)" rev-parse -q --verify "refs/tags/$($(@)_BRANCH)" >/dev/null; \
+	then \
+	  $(GIT) -c advice.detachedHead=false -C "$($(@)_PATH)" checkout "refs/tags/$($(@)_BRANCH)"; \
+	elif $(GIT) -C "$($(@)_PATH)" rev-parse -q --verify "origin/$($(@)_NAME)-$($(@)_BRANCH)" >/dev/null; \
+	then \
+	  $(GIT) -c advice.detachedHead=false -C "$($(@)_PATH)" checkout -B "$($(@)_NAME)-$($(@)_BRANCH)" "origin/$($(@)_NAME)-$($(@)_BRANCH)"; \
+	else \
+	  $(GIT) -c advice.detachedHead=false -C "$($(@)_PATH)" checkout "refs/tags/$($(@)_NAME)-$($(@)_BRANCH)"; \
+	fi
 
 fetch: $(SRC_MODULES) $(HDR_MODULES) $(BIN_MODULES) $(PLUG_MODULES)
 


### PR DESCRIPTION
This silences tons of errors like

```
Cloning https://github.com/lsp-plugins/lsp-common-lib.git -> /tmp/lsp-plugins/modules/lsp-common-lib [1.0.36]
HEAD is now at 23dec90 Release 1.0.36
fatal: 'origin/1.0.36' is not a commit and a branch '1.0.36' cannot be created from it
```

Since you execute multiple git-commands or-ed, I assume failure of all but the last git command is fine, and so the associated error messages should be hidden from the user to avoid confusion. Feel free to ignore the PR if this is not wanted :smiley: 